### PR TITLE
Circle coordinates

### DIFF
--- a/bag.py
+++ b/bag.py
@@ -3,7 +3,6 @@ import color
 
 from screen import screen
 from circle import Circle
-from constants import *
 from vec2 import Vec2
 
 class BagSlot(Circle):

--- a/bag.py
+++ b/bag.py
@@ -26,7 +26,7 @@ class BagSlot(Circle):
         screen.blit(textSurface, textRect)
 
 DRIVER = BagSlot(Vec2(750, 50), 20, 'Driver', color.WHITE, 0.01)
-MID_RANGE = BagSlot(Vec2(700, 50), 20, 'Mid Range', color.BLUE, 0.015)
-PUTTER = BagSlot(Vec2(650, 50), 20, 'Putter', color.ORANGE, 0.02)
+MID_RANGE = BagSlot(Vec2(685, 50), 20, 'Mid Range', color.BLUE, 0.015)
+PUTTER = BagSlot(Vec2(620, 50), 20, 'Putter', color.ORANGE, 0.02)
 
 BAG = [DRIVER, MID_RANGE, PUTTER]

--- a/bag.py
+++ b/bag.py
@@ -16,13 +16,13 @@ class BagSlot(Circle):
         if hoverCheck == True:
             pygame.draw.circle(screen,
                                color.LIGHT_GREY,
-                               [int(self.center.x), int(self.center.y)],
+                               [int(self.center().x), int(self.center().y)],
                                int((self.radius + 10) * 0.5),
                                width=0)
         super().draw(self.color)
         textSurface = pygame.font.Font('freesansbold.ttf', 12).render(self.name, True, color.WHITE)
         textRect = textSurface.get_rect()
-        textRect.center = (int(self.center.x), int(self.pos.y - 15))
+        textRect.center = (int(self.center().x), int(self.pos.y - 15))
         screen.blit(textSurface, textRect)
 
 DRIVER = BagSlot(Vec2(750, 50), 40, 'Driver', color.WHITE, 0.01)

--- a/bag.py
+++ b/bag.py
@@ -16,13 +16,13 @@ class BagSlot(Circle):
         if hoverCheck == True:
             pygame.draw.circle(screen,
                                color.LIGHT_GREY,
-                               [int(self.center().x), int(self.center().y)],
+                               [int(self.pos.x), int(self.pos.y)],
                                int(self.radius + 5),
                                width=0)
         super().draw(self.color)
         textSurface = pygame.font.Font('freesansbold.ttf', 12).render(self.name, True, color.WHITE)
         textRect = textSurface.get_rect()
-        textRect.center = (int(self.center().x), int(self.pos.y - 15))
+        textRect.center = (int(self.pos.x), int(self.pos.y - 15))
         screen.blit(textSurface, textRect)
 
 DRIVER = BagSlot(Vec2(750, 50), 20, 'Driver', color.WHITE, 0.01)

--- a/bag.py
+++ b/bag.py
@@ -22,7 +22,7 @@ class BagSlot(Circle):
         super().draw(self.color)
         textSurface = pygame.font.Font('freesansbold.ttf', 12).render(self.name, True, color.WHITE)
         textRect = textSurface.get_rect()
-        textRect.center = (int(self.pos.x), int(self.pos.y - 15))
+        textRect.center = (int(self.pos.x), int(self.pos.y - self.radius - 15))
         screen.blit(textSurface, textRect)
 
 DRIVER = BagSlot(Vec2(750, 50), 20, 'Driver', color.WHITE, 0.01)

--- a/bag.py
+++ b/bag.py
@@ -9,7 +9,6 @@ from vec2 import Vec2
 class BagSlot(Circle):
     def __init__(self, pos, radius, name, color, resistance_coef):
         super().__init__(pos, radius)
-        self.pos = pos
         self.color = color
         self.center = Vec2(int(pos.x + 0.5 * radius), int(pos.y + 0.5 * radius))
         self.name = name

--- a/bag.py
+++ b/bag.py
@@ -22,7 +22,7 @@ class BagSlot(Circle):
         super().draw(self.color)
         textSurface = pygame.font.Font('freesansbold.ttf', 12).render(self.name, True, color.WHITE)
         textRect = textSurface.get_rect()
-        textRect.center = (int(self.pos.x + self.radius * 0.5), int(self.pos.y - 15))
+        textRect.center = (int(self.center.x), int(self.pos.y - 15))
         screen.blit(textSurface, textRect)
 
 DRIVER = BagSlot(Vec2(750, 50), 40, 'Driver', color.WHITE, 0.01)

--- a/bag.py
+++ b/bag.py
@@ -16,7 +16,7 @@ class BagSlot(Circle):
         if hoverCheck == True:
             pygame.draw.circle(screen,
                                color.LIGHT_GREY,
-                               [int(self.pos.x + 0.5 * self.radius), int(self.pos.y + 0.5 * self.radius)],
+                               [int(self.center.x), int(self.center.y)],
                                int((self.radius + 10) * 0.5),
                                width=0)
         super().draw(self.color)

--- a/bag.py
+++ b/bag.py
@@ -25,8 +25,8 @@ class BagSlot(Circle):
         textRect.center = (int(self.center().x), int(self.pos.y - 15))
         screen.blit(textSurface, textRect)
 
-DRIVER = BagSlot(Vec2(750, 50), 40, 'Driver', color.WHITE, 0.01)
-MID_RANGE = BagSlot(Vec2(700, 50), 40, 'Mid Range', color.BLUE, 0.015)
-PUTTER = BagSlot(Vec2(650, 50), 40, 'Putter', color.ORANGE, 0.02)
+DRIVER = BagSlot(Vec2(750, 50), 20, 'Driver', color.WHITE, 0.01)
+MID_RANGE = BagSlot(Vec2(700, 50), 20, 'Mid Range', color.BLUE, 0.015)
+PUTTER = BagSlot(Vec2(650, 50), 20, 'Putter', color.ORANGE, 0.02)
 
 BAG = [DRIVER, MID_RANGE, PUTTER]

--- a/bag.py
+++ b/bag.py
@@ -10,7 +10,6 @@ class BagSlot(Circle):
     def __init__(self, pos, radius, name, color, resistance_coef):
         super().__init__(pos, radius)
         self.pos = pos
-        self.r = radius
         self.color = color
         self.center = Vec2(int(pos.x + 0.5 * radius), int(pos.y + 0.5 * radius))
         self.name = name
@@ -19,13 +18,13 @@ class BagSlot(Circle):
         if hoverCheck == True:
             pygame.draw.circle(screen,
                                color.LIGHT_GREY,
-                               [int(self.pos.x + 0.5 * self.r), int(self.pos.y + 0.5 * self.r)],
-                               int((self.r + 10) * 0.5),
+                               [int(self.pos.x + 0.5 * self.radius), int(self.pos.y + 0.5 * self.radius)],
+                               int((self.radius + 10) * 0.5),
                                width=0)
         super().draw(self.color)
         textSurface = pygame.font.Font('freesansbold.ttf', 12).render(self.name, True, color.WHITE)
         textRect = textSurface.get_rect()
-        textRect.center = (int(self.pos.x + self.r * 0.5), int(self.pos.y - 15))
+        textRect.center = (int(self.pos.x + self.radius * 0.5), int(self.pos.y - 15))
         screen.blit(textSurface, textRect)
 
 DRIVER = BagSlot(Vec2(750, 50), 40, 'Driver', color.WHITE, 0.01)

--- a/bag.py
+++ b/bag.py
@@ -10,7 +10,6 @@ class BagSlot(Circle):
     def __init__(self, pos, radius, name, color, resistance_coef):
         super().__init__(pos, radius)
         self.color = color
-        self.center = Vec2(int(pos.x + 0.5 * radius), int(pos.y + 0.5 * radius))
         self.name = name
         self.resistance_coef = resistance_coef
     def draw(self, hoverCheck):

--- a/bag.py
+++ b/bag.py
@@ -18,10 +18,10 @@ class BagSlot(Circle):
     def draw(self, hoverCheck):
         if hoverCheck == True:
             pygame.draw.circle(screen,
-                              color.LIGHT_GREY,
-                              [int(self.pos.x + 0.5 * self.r), int(self.pos.y + 0.5 * self.r)],
-                              int((self.r + 10) * 0.5),
-                              width=0)
+                               color.LIGHT_GREY,
+                               [int(self.pos.x + 0.5 * self.r), int(self.pos.y + 0.5 * self.r)],
+                               int((self.r + 10) * 0.5),
+                               width=0)
         super().draw(self.color)
         textSurface = pygame.font.Font('freesansbold.ttf', 12).render(self.name, True, color.WHITE)
         textRect = textSurface.get_rect()

--- a/bag.py
+++ b/bag.py
@@ -17,7 +17,7 @@ class BagSlot(Circle):
             pygame.draw.circle(screen,
                                color.LIGHT_GREY,
                                [int(self.center().x), int(self.center().y)],
-                               int((self.radius + 10) * 0.5),
+                               int(self.radius + 5),
                                width=0)
         super().draw(self.color)
         textSurface = pygame.font.Font('freesansbold.ttf', 12).render(self.name, True, color.WHITE)

--- a/circle.py
+++ b/circle.py
@@ -7,6 +7,7 @@ class Circle:
     def __init__(self, pos, radius):
         self.pos = pos
         self.radius = radius
-        self.center = pos + Vec2(radius / 2, radius / 2)
+    def center(self):
+        return self.pos + Vec2(self.radius / 2, self.radius / 2)
     def draw(self, color):
         pygame.draw.ellipse(screen, color, [int(self.pos.x), int(self.pos.y), self.radius, self.radius])

--- a/circle.py
+++ b/circle.py
@@ -7,5 +7,6 @@ class Circle:
     def __init__(self, pos, radius):
         self.pos = pos
         self.radius = radius
+        self.center = pos + Vec2(radius / 2, radius / 2)
     def draw(self, color):
         pygame.draw.ellipse(screen, color, [int(self.pos.x), int(self.pos.y), self.radius, self.radius])

--- a/circle.py
+++ b/circle.py
@@ -7,5 +7,7 @@ class Circle:
     def __init__(self, pos, radius):
         self.pos = pos
         self.radius = radius
+    def hit(self, pos):
+        return (self.pos - pos).norm() <= self.radius
     def draw(self, color):
         pygame.draw.circle(screen, color, [int(self.pos.x), int(self.pos.y)], self.radius)

--- a/circle.py
+++ b/circle.py
@@ -10,4 +10,4 @@ class Circle:
     def center(self):
         return self.pos + Vec2(self.radius / 2, self.radius / 2)
     def draw(self, color):
-        pygame.draw.ellipse(screen, color, [int(self.pos.x), int(self.pos.y), self.radius, self.radius])
+        pygame.draw.circle(screen, color, [int(self.center().x), int(self.center().y)], self.radius / 2)

--- a/circle.py
+++ b/circle.py
@@ -8,6 +8,6 @@ class Circle:
         self.pos = pos
         self.radius = radius
     def center(self):
-        return self.pos + Vec2(self.radius / 2, self.radius / 2)
+        return self.pos + Vec2(self.radius, self.radius)
     def draw(self, color):
-        pygame.draw.circle(screen, color, [int(self.center().x), int(self.center().y)], self.radius / 2)
+        pygame.draw.circle(screen, color, [int(self.center().x), int(self.center().y)], self.radius)

--- a/circle.py
+++ b/circle.py
@@ -7,7 +7,5 @@ class Circle:
     def __init__(self, pos, radius):
         self.pos = pos
         self.radius = radius
-    def center(self):
-        return self.pos + Vec2(self.radius, self.radius)
     def draw(self, color):
-        pygame.draw.circle(screen, color, [int(self.center().x), int(self.center().y)], self.radius)
+        pygame.draw.circle(screen, color, [int(self.pos.x), int(self.pos.y)], self.radius)

--- a/disc.py
+++ b/disc.py
@@ -23,7 +23,7 @@ class Disc(Circle):
     def throw(self, mouse_movement):
         self.vel = Vec2(mouse_movement[0], mouse_movement[1]) * 2.0
     def hit(self, obs):
-        return (self.pos - obs.pos).norm() <= (self.radius + obs.radius) / 2
+        return (self.center() - obs.center()).norm() <= (self.radius + obs.radius)
     def speed(self):
         return self.vel.norm()
     def relative_speed2(self, wind):

--- a/disc.py
+++ b/disc.py
@@ -23,7 +23,7 @@ class Disc(Circle):
     def throw(self, mouse_movement):
         self.vel = Vec2(mouse_movement[0], mouse_movement[1]) * 2.0
     def hit(self, obs):
-        return (self.center() - obs.center()).norm() <= (self.radius + obs.radius)
+        return (self.pos - obs.pos).norm() <= (self.radius + obs.radius)
     def speed(self):
         return self.vel.norm()
     def relative_speed2(self, wind):

--- a/main.py
+++ b/main.py
@@ -40,12 +40,12 @@ while True:
         if event.type == pygame.MOUSEBUTTONDOWN:
             # Change disc parameters
             for slot in BAG:
-                if (slot.center - mouse).norm() <= slot.r and disc.speed() == 0.0:
+                if (slot.center - mouse).norm() <= slot.radius and disc.speed() == 0.0:
                     disc.color = slot.color
                     disc.resistance_coef = slot.resistance_coef
             # Space not valid when choosing discs
         for slot in BAG:
-            if (slot.center - mouse).norm() <= slot.r:
+            if (slot.center - mouse).norm() <= slot.radius:
                 validSpace = False
                 break
         if event.type == pygame.QUIT:
@@ -93,7 +93,7 @@ while True:
 
     # Change color of bag slot if hovering over an option
     for slot in BAG:
-        if (slot.center - mouse).norm() <= slot.r:
+        if (slot.center - mouse).norm() <= slot.radius:
             slot.draw(hoverCheck=True)
         else:
             slot.draw(hoverCheck=False)

--- a/main.py
+++ b/main.py
@@ -26,10 +26,10 @@ clock = pygame.time.Clock()
 mouse_down = False
 stroke_count = 0
 
-basket = Circle(Vec2(390, 120), 20)
-trees = [Circle(Vec2(400, 300), 10), Circle(Vec2(400, 350), 10), Circle(Vec2(350, 300), 10)]
-wind = Wind(50, 50, 100, max_speed=50)
-disc = Disc(Vec2(395, 500), 10, color=BAG[0].color, resistance_coef=BAG[0].resistance_coef)
+basket = Circle(Vec2(390, 120), 10)
+trees = [Circle(Vec2(400, 300), 5), Circle(Vec2(400, 350), 5), Circle(Vec2(350, 300), 5)]
+wind = Wind(50, 50, 50, max_speed=50)
+disc = Disc(Vec2(395, 500), 5, color=BAG[0].color, resistance_coef=BAG[0].resistance_coef)
 validSpace = True
 
 while True:

--- a/main.py
+++ b/main.py
@@ -40,12 +40,12 @@ while True:
         if event.type == pygame.MOUSEBUTTONDOWN:
             # Change disc parameters
             for slot in BAG:
-                if (slot.center - mouse).norm() <= slot.radius and disc.speed() == 0.0:
+                if (slot.center() - mouse).norm() <= slot.radius and disc.speed() == 0.0:
                     disc.color = slot.color
                     disc.resistance_coef = slot.resistance_coef
             # Space not valid when choosing discs
         for slot in BAG:
-            if (slot.center - mouse).norm() <= slot.radius:
+            if (slot.center() - mouse).norm() <= slot.radius:
                 validSpace = False
                 break
         if event.type == pygame.QUIT:
@@ -93,7 +93,7 @@ while True:
 
     # Change color of bag slot if hovering over an option
     for slot in BAG:
-        if (slot.center - mouse).norm() <= slot.radius:
+        if (slot.center() - mouse).norm() <= slot.radius:
             slot.draw(hoverCheck=True)
         else:
             slot.draw(hoverCheck=False)

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 #!/usr/local/bin/python3
 
 import sys
-import numpy as np
 import pygame
 
 import color

--- a/main.py
+++ b/main.py
@@ -40,12 +40,12 @@ while True:
         if event.type == pygame.MOUSEBUTTONDOWN:
             # Change disc parameters
             for slot in BAG:
-                if (slot.pos - mouse).norm() <= slot.radius and disc.speed() == 0.0:
+                if slot.hit(mouse) and disc.speed() == 0.0:
                     disc.color = slot.color
                     disc.resistance_coef = slot.resistance_coef
             # Space not valid when choosing discs
         for slot in BAG:
-            if (slot.pos - mouse).norm() <= slot.radius:
+            if slot.hit(mouse):
                 validSpace = False
                 break
         if event.type == pygame.QUIT:
@@ -92,7 +92,7 @@ while True:
 
     # Change color of bag slot if hovering over an option
     for slot in BAG:
-        if (slot.pos - mouse).norm() <= slot.radius:
+        if slot.hit(mouse):
             slot.draw(hoverCheck=True)
         else:
             slot.draw(hoverCheck=False)

--- a/main.py
+++ b/main.py
@@ -26,10 +26,10 @@ clock = pygame.time.Clock()
 mouse_down = False
 stroke_count = 0
 
-basket = Circle(Vec2(390, 120), 10)
+basket = Circle(Vec2(400, 120), 10)
 trees = [Circle(Vec2(400, 300), 5), Circle(Vec2(400, 350), 5), Circle(Vec2(350, 300), 5)]
-wind = Wind(Vec2(50, 50), 50, max_speed=50)
-disc = Disc(Vec2(395, 500), 5, color=BAG[0].color, resistance_coef=BAG[0].resistance_coef)
+wind = Wind(Vec2(100, 100), 50, max_speed=50)
+disc = Disc(Vec2(400, 500), 5, color=BAG[0].color, resistance_coef=BAG[0].resistance_coef)
 validSpace = True
 
 while True:

--- a/main.py
+++ b/main.py
@@ -83,7 +83,6 @@ while True:
     # Draw objects
     DrawHole()
     basket.draw(color.GREY)
-    disc.draw()
     wind.draw()
 
     for tree in trees:
@@ -97,6 +96,8 @@ while True:
             slot.draw(hoverCheck=True)
         else:
             slot.draw(hoverCheck=False)
+
+    disc.draw()
 
     # Finish cycle
     pygame.display.update()

--- a/main.py
+++ b/main.py
@@ -40,12 +40,12 @@ while True:
         if event.type == pygame.MOUSEBUTTONDOWN:
             # Change disc parameters
             for slot in BAG:
-                if (slot.center() - mouse).norm() <= slot.radius and disc.speed() == 0.0:
+                if (slot.pos - mouse).norm() <= slot.radius and disc.speed() == 0.0:
                     disc.color = slot.color
                     disc.resistance_coef = slot.resistance_coef
             # Space not valid when choosing discs
         for slot in BAG:
-            if (slot.center() - mouse).norm() <= slot.radius:
+            if (slot.pos - mouse).norm() <= slot.radius:
                 validSpace = False
                 break
         if event.type == pygame.QUIT:
@@ -92,7 +92,7 @@ while True:
 
     # Change color of bag slot if hovering over an option
     for slot in BAG:
-        if (slot.center() - mouse).norm() <= slot.radius:
+        if (slot.pos - mouse).norm() <= slot.radius:
             slot.draw(hoverCheck=True)
         else:
             slot.draw(hoverCheck=False)

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ stroke_count = 0
 
 basket = Circle(Vec2(390, 120), 10)
 trees = [Circle(Vec2(400, 300), 5), Circle(Vec2(400, 350), 5), Circle(Vec2(350, 300), 5)]
-wind = Wind(50, 50, 50, max_speed=50)
+wind = Wind(Vec2(50, 50), 50, max_speed=50)
 disc = Disc(Vec2(395, 500), 5, color=BAG[0].color, resistance_coef=BAG[0].resistance_coef)
 validSpace = True
 

--- a/vec2.py
+++ b/vec2.py
@@ -7,6 +7,8 @@ class Vec2:
     @classmethod
     def from_tuple(cls, tuple):
         return cls(tuple[0], tuple[1])
+    def as_tuple(self):
+        return [self.x, self.y]
     def __add__(self, rhs):
         return Vec2(self.x + rhs.x, self.y + rhs.y)
     def __sub__(self, rhs):

--- a/wind.py
+++ b/wind.py
@@ -18,11 +18,9 @@ class Wind(Circle):
         return text_surface, text_surface.get_rect()
     def draw(self):
         super().draw(color.LIGHT_GREY)
-        start_pos = (int(self.pos.x + self.radius * 0.5),
-                     int(self.pos.y + self.radius * 0.5))
-        end_pos = (int(start_pos[0] + 0.5 * self.radius * np.cos(self.heading)),
-                   int(start_pos[1] + 0.5 * self.radius * np.sin(self.heading)))
-        pygame.draw.line(screen, color.WHITE, start_pos, end_pos, width=5)
+        start_pos = self.center()
+        end_pos = self.center() + Vec2(np.cos(self.heading), np.sin(self.heading)) * self.radius * 0.5
+        pygame.draw.line(screen, color.WHITE, start_pos.as_tuple(), end_pos.as_tuple(), width=5)
         wind_speed_text = pygame.font.Font('freesansbold.ttf', 16)
         text = ('Wind Speed: ' + str(round(self.speed, 1)))
         text_surf, text_rect = self.text_objects(text, wind_speed_text)

--- a/wind.py
+++ b/wind.py
@@ -24,7 +24,7 @@ class Wind(Circle):
         wind_speed_text = pygame.font.Font('freesansbold.ttf', 16)
         text = ('Wind Speed: ' + str(round(self.speed, 1)))
         text_surf, text_rect = self.text_objects(text, wind_speed_text)
-        text_rect.center = (int(self.pos.x), int(self.pos.y - 15))
+        text_rect.center = (int(self.pos.x), int(self.pos.y - self.radius - 15))
         screen.blit(text_surf, text_rect)
     speed: float = 0.0
     heading: float = 0.0

--- a/wind.py
+++ b/wind.py
@@ -18,13 +18,13 @@ class Wind(Circle):
         return text_surface, text_surface.get_rect()
     def draw(self):
         super().draw(color.LIGHT_GREY)
-        start_pos = self.center()
-        end_pos = self.center() + Vec2(np.cos(self.heading), np.sin(self.heading)) * self.radius
+        start_pos = self.pos
+        end_pos = self.pos + Vec2(np.cos(self.heading), np.sin(self.heading)) * self.radius
         pygame.draw.line(screen, color.WHITE, start_pos.as_tuple(), end_pos.as_tuple(), width=5)
         wind_speed_text = pygame.font.Font('freesansbold.ttf', 16)
         text = ('Wind Speed: ' + str(round(self.speed, 1)))
         text_surf, text_rect = self.text_objects(text, wind_speed_text)
-        text_rect.center = (int(self.center().x), int(self.pos.y - 15))
+        text_rect.center = (int(self.pos.x), int(self.pos.y - 15))
         screen.blit(text_surf, text_rect)
     speed: float = 0.0
     heading: float = 0.0

--- a/wind.py
+++ b/wind.py
@@ -8,8 +8,8 @@ from circle import Circle
 from vec2 import Vec2
 
 class Wind(Circle):
-    def __init__(self, x, y, radius, max_speed):
-        super().__init__(Vec2(x, y), radius)
+    def __init__(self, pos, radius, max_speed):
+        super().__init__(pos, radius)
         self.speed = np.random.rand() * max_speed
         self.heading = np.deg2rad(np.random.randint(360))
         self.vel = Vec2(np.cos(self.heading), np.sin(self.heading)) * self.speed

--- a/wind.py
+++ b/wind.py
@@ -19,7 +19,7 @@ class Wind(Circle):
     def draw(self):
         super().draw(color.LIGHT_GREY)
         start_pos = self.center()
-        end_pos = self.center() + Vec2(np.cos(self.heading), np.sin(self.heading)) * self.radius * 0.5
+        end_pos = self.center() + Vec2(np.cos(self.heading), np.sin(self.heading)) * self.radius
         pygame.draw.line(screen, color.WHITE, start_pos.as_tuple(), end_pos.as_tuple(), width=5)
         wind_speed_text = pygame.font.Font('freesansbold.ttf', 16)
         text = ('Wind Speed: ' + str(round(self.speed, 1)))

--- a/wind.py
+++ b/wind.py
@@ -24,7 +24,7 @@ class Wind(Circle):
         wind_speed_text = pygame.font.Font('freesansbold.ttf', 16)
         text = ('Wind Speed: ' + str(round(self.speed, 1)))
         text_surf, text_rect = self.text_objects(text, wind_speed_text)
-        text_rect.center = (int(self.pos.x + self.radius * 0.5), int(self.pos.y - 15))
+        text_rect.center = (int(self.center().x), int(self.pos.y - 15))
         screen.blit(text_surf, text_rect)
     speed: float = 0.0
     heading: float = 0.0


### PR DESCRIPTION
Fixed how program handles circle coordinates. Previous, circle origins were defined as the top left corner of a bounding square. This was unintuitive and bug prone. Collision detection never worked as intended until we switched to using circle centers as origins.